### PR TITLE
Add 'rain' and 'snow' to struct WeatherReportCurrent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Cargo.lock
 **/*.rs.bk
 
 .env
+
+# Vim backup files
+**/*.swp

--- a/src/weather_types.rs
+++ b/src/weather_types.rs
@@ -145,6 +145,8 @@ pub struct WeatherReportCurrent {
     pub main: Main,
     pub visibility: u32,
     pub wind: Wind,
+    pub rain: Option<Rain>,
+    pub snow: Option<Snow>,
     pub clouds: Clouds,
     pub dt: u64,
     pub sys: Sys,


### PR DESCRIPTION
Rain and Snow structs were already defined but were not yet included in the WeatherReportCurrent struct, although they do occur in the JSON response from OpenWeatherMaps.

As listed in OpenWeatherMap [API docs on current weather](https://openweathermap.org/current), "rain" and "snow" can (and do) appear in the JSON response from the API, but strangely were not included in the struct WeatherReportCurrent up to this point.

Although we love sunny weather, this pull request adds support for rain and snow!